### PR TITLE
Added yml and yaml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,26 +133,28 @@ class ServerlessOutputPlugin implements Plugin {
 		);
 	}
 
-	format(exports: Exports, format: string) {
-		switch (format.toLowerCase()) {
-			case "toml":
-				throw new Error("Not implemented yet");
-
-			case "yaml":
-				throw new Error("Not implemented yet");
-
-			case "json":
-				throw new Error("Not implemented yet");
-
-			case "env":
-				return Object.entries(exports)
-					.map(([key, value]) => `${key}=${value}`)
-					.join("\n");
-
-			default:
-				throw new Error(`Format ${format} is not supported`);
-		}
-	}
+	format(exports, format) {
+        switch (format.toLowerCase()) {
+            case "toml":
+                throw new Error("Not implemented yet");
+            case "yaml":
+                return Object.entries(exports)
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join("\n");
+            case "yml":
+                return Object.entries(exports)
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join("\n");
+            case "json":
+                throw new Error("Not implemented yet");
+            case "env":
+                return Object.entries(exports)
+                    .map(([key, value]) => `${key}=${value}`)
+                    .join("\n");
+            default:
+                throw new Error(`Format ${format} is not supported`);
+        }
+    }
 
 	write(
 		exports: Exports,

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ class ServerlessOutputPlugin implements Plugin {
 		);
 	}
 
-	format(exports, format) {
+	format(exports: Exports, format: string) {
         switch (format.toLowerCase()) {
             case "toml":
                 throw new Error("Not implemented yet");

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,9 +138,6 @@ class ServerlessOutputPlugin implements Plugin {
             case "toml":
                 throw new Error("Not implemented yet");
             case "yaml":
-                return Object.entries(exports)
-                    .map(([key, value]) => `${key}: ${value}`)
-                    .join("\n");
             case "yml":
                 return Object.entries(exports)
                     .map(([key, value]) => `${key}: ${value}`)


### PR DESCRIPTION
Thanks for this stellar plugin. I added the below for yml and yaml files which aligns with more widely found guidance for referencing variables directly from a file, vs. loading them from a file into the environment vi .env. Working well in my use case, but I'd like to be able to integrate into the plugin for dynamic download, since I am currently excluding local node modules folder from copying to my container on build. Thanks!