### PR TITLE
fix: install chalk as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/node": "^20.5.0",
     "@types/serverless": "^3.12.14",
     "aws-sdk": "^2.1437.0",
-    "chalk": "^4.0.0",
     "execa": "^7.2.0",
     "js-yaml": "^4.1.0",
     "json-schema-to-ts": "^2.9.2",
@@ -49,6 +48,9 @@
     "serverless-localstack": "^1.1.1",
     "typescript": "^5.1.6",
     "vitest": "^0.34.1"
+  },
+  "dependencies": {
+    "chalk": "^4.0.0"
   },
   "peerDependencies": {
     "serverless": "^3.0.0 || ^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      chalk:
+        specifier: ^4.0.0
+        version: 4.1.2
     devDependencies:
       '@aws-sdk/types':
         specifier: ^3.391.0
@@ -29,9 +33,6 @@ importers:
       aws-sdk:
         specifier: ^2.1437.0
         version: 2.1437.0
-      chalk:
-        specifier: ^4.0.0
-        version: 4.1.2
       execa:
         specifier: ^7.2.0
         version: 7.2.0


### PR DESCRIPTION
Install `chalk` as dependency instead of devDependency

Fixes #3 